### PR TITLE
Update Медицина.md

### DIFF
--- a/Медицина.md
+++ b/Медицина.md
@@ -44,7 +44,6 @@ HNO-Arzt Dr. Alexander Bogdanoff
 
 
 #### Англоязычные врачи (рекомендации посольств)
-  - Список посольства US: http://photos.state.gov/libraries/frankfurt/9318/english%20speaking%20services/Berlin%20Brandenburg%20Attorney%20List.pdf
   - Список посольства UK: https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/440519/medical_germany.pdf
 
 


### PR DESCRIPTION
для US была ссылка на адвокатов (кстати, там еще есть налоговые консультанты), вместо врачей. Сссылка на врачей есть, но недавно стала выдавать 404. Поэтому оставляем только UK.